### PR TITLE
`github-linguist --breakdown` reflects code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 vignettes/*.html linguist-documentation
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.html linguist-documentation
+vignettes/*.html linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,1 @@
-vignettes/** linguist-documentation
-docs/** linguist-documentation
-vignettes/** linguist-vendored
-docs/** linguist-vendored
 *.html linguist-documentation
-*.HTML linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-vignettes/ linguist-documentation
-tests/ linguist-documentation
+vignettes/** linguist-documentation
+tests/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+vignettes/** linguist-documentation
+docs/** linguist-documentation
+vignettes/** linguist-vendored
+docs/** linguist-vendored
+*.html linguist-documentation
+*.HTML linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-vignettes/*.html linguist-documentation
-
+vignettes/ linguist-documentation
+tests/ linguist-documentation

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ src/*.dll
 .Rdata
 .httr-oauth
 .DS_Store
-vignettes/*.html
-docs/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/*.dll
 .Rdata
 .httr-oauth
 .DS_Store
+.html

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ src/*.dll
 .Rdata
 .httr-oauth
 .DS_Store
-.html
+vignettes/*.html
+docs/*.html


### PR DESCRIPTION
Previously, the language bar was dominated by `.html` due to detection by github-linguist as code and not as documentation. This is an attempt to remedy this and it works at least in the command line.
```
$ github-linguist
95.39%  475245     R
4.61%   22969      C++
```