### PR TITLE
github-linguist --breakdown reflects code [redo]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+vignettes/*.html linguist-vendored=false
+docs/*.html linguist-vendored=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 vignettes/** linguist-documentation
 docs/** linguist-documentation
-*.html linguist-detectable=false
+vignettes/*.html linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 vignettes/** linguist-documentation
 docs/** linguist-documentation
 vignettes/*.html linguist-detectable=false
-.R linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 vignettes/** linguist-documentation
 docs/** linguist-documentation
 vignettes/*.html linguist-detectable=false
+.R linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-vignettes/**.html linguist-vendored=false
-docs/**.html linguist-vendored=false
+vignettes/** linguist-vendored=false
+docs/** linguist-vendored=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 vignettes/** linguist-documentation
 docs/** linguist-documentation
+*.html linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-vignettes/** linguist-vendored=false
-docs/** linguist-vendored=false
+vignettes/** linguist-documentation
+docs/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-vignettes/*.html linguist-vendored=false
-docs/*.html linguist-vendored=false
+vignettes/**.html linguist-vendored=false
+docs/**.html linguist-vendored=false

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ src/*.dll
 .Rdata
 .httr-oauth
 .DS_Store
-vignettes/*.html
-docs/*.html
+vignettes/**
+docs/**

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ src/*.dll
 .Rdata
 .httr-oauth
 .DS_Store
-vignettes/**
-docs/**

--- a/vignettes/.gitattributes
+++ b/vignettes/.gitattributes
@@ -1,1 +1,0 @@
-*.html linguist-detectable=false

--- a/vignettes/.gitattributes
+++ b/vignettes/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
Previously:

Previously, the language bar was dominated by `.html` due to detection by github-linguist as code and not as documentation. This is an attempt to remedy this and it works at least in the command line.

```
$ github-linguist
95.39%  475245     R
4.61%   22969      C++
```

I think I made a mistake due to confusing repo names and it being a bit late in the day.